### PR TITLE
fix(license) updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,6 @@ Or write a `zram_teardown.sls` state.
 
 ---
 
-## 📜 License
-
-MIT License — feel free to use and adapt.
-
----
-
 ## 🤝 Contributing
 
 Pull requests, feedback, and suggestions are welcome!


### PR DESCRIPTION
removed license from readme file as it was incorrect. serves me right for copy-pasting from my other local repos.