### PR TITLE
docs: fix systemd documentation link

### DIFF
--- a/systemd/zram.service
+++ b/systemd/zram.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Configure ZRAM swap devices
-Documentation=https://github.com/yourusername/zram-setup-script
+Documentation=https://github.com/tim0n3/zram
 DefaultDependencies=no
 After=systemd-modules-load.service local-fs.target
 Before=swap.target

--- a/systemd/zram.service
+++ b/systemd/zram.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Configure ZRAM swap devices
-Documentation=https://github.com/tim0n3/zram
+Documentation=https://github.com/tim0n3/zram/blob/master/docs/installation_and_usage.md
 DefaultDependencies=no
 After=systemd-modules-load.service local-fs.target
 Before=swap.target


### PR DESCRIPTION
Updates the systemd service Documentation URL to point at the correct repo. Closes #7.