### PR TITLE
docs: add permissions note for zram-daemon.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ sudo systemctl enable --now zram.service
 
 Create `/etc/zram-daemon.conf` to override defaults:
 
+Permissions: ensure the file is owned by `root:root` and not writable by non-root users (mode `0644`).
+
 ```bash
 COMPRESSION_ALGO="zstd"
 ZRAM_PRIORITY=100

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ sudo systemctl enable --now zram.service
 
 Create `/etc/zram-daemon.conf` to override defaults:
 
-Permissions: ensure the file is owned by `root:root` and not writable by non-root users (mode `0644`).
+**Security Note**: Ensure the file is owned by `root:root` with permissions `0644` to prevent unauthorized modification.
 
 ```bash
 COMPRESSION_ALGO="zstd"

--- a/docs/installation_and_usage.md
+++ b/docs/installation_and_usage.md
@@ -44,6 +44,8 @@ The `zram.sh` script is designed to run as a systemd-managed, one-shot daemon on
 
 Create `/etc/zram-daemon.conf` to override defaults:
 
+Permissions: ensure the file is owned by `root:root` and not writable by non-root users (mode `0644`).
+
 ```bash
 # Example configuration overrides
 COMPRESSION_ALGO="zstd"

--- a/docs/installation_and_usage.md
+++ b/docs/installation_and_usage.md
@@ -44,7 +44,7 @@ The `zram.sh` script is designed to run as a systemd-managed, one-shot daemon on
 
 Create `/etc/zram-daemon.conf` to override defaults:
 
-Permissions: ensure the file is owned by `root:root` and not writable by non-root users (mode `0644`).
+**Security Note**: Ensure the file is owned by `root:root` with permissions `0644` to prevent unauthorized modification.
 
 ```bash
 # Example configuration overrides


### PR DESCRIPTION
Adds a security note advising root ownership and 0644 permissions for /etc/zram-daemon.conf. Closes #6.